### PR TITLE
Support Psych 4.x gem

### DIFF
--- a/app/models/casino/user.rb
+++ b/app/models/casino/user.rb
@@ -1,6 +1,6 @@
 
 class CASino::User < CASino::ApplicationRecord
-  serialize :extra_attributes, Hash
+  serialize :extra_attributes, coder: YAML, type: Hash
 
   has_many :ticket_granting_tickets, dependent: :destroy
   has_many :two_factor_authenticators, dependent: :destroy

--- a/casino.gemspec
+++ b/casino.gemspec
@@ -23,12 +23,13 @@ Gem::Specification.new do |s|
     s.cert_chain  = ['casino-public_cert.pem']
   end
 
+  s.required_ruby_version = '>= 3.1.0'
   s.add_runtime_dependency 'addressable', '>= 2.3'
   s.add_runtime_dependency 'faraday', '>= 0.15.4'
   s.add_runtime_dependency 'grape', '>= 0.8'
   s.add_runtime_dependency 'grape-entity', '>= 0.4'
   s.add_runtime_dependency 'kaminari', '>= 1.2.1'
-  s.add_runtime_dependency 'rails', '>= 4.2'
+  s.add_runtime_dependency 'rails', '>= 7.1'
   s.add_runtime_dependency 'rotp', '>= 2.0'
   s.add_runtime_dependency 'rqrcode', '~> 0.10.1'
   s.add_runtime_dependency 'rqrcode_png', '>= 0.1'

--- a/lib/casino/engine.rb
+++ b/lib/casino/engine.rb
@@ -14,7 +14,7 @@ module CASino
 
     private
     def apply_yaml_config(yaml)
-      cfg = (YAML.load(ERB.new(yaml).result)||{}).fetch(Rails.env, {})
+      cfg = (YAML.load(ERB.new(yaml).result, aliases: true)||{}).fetch(Rails.env, {})
       cfg.each do |k,v|
         value = if v.is_a? Hash
           CASino.config.fetch(k.to_sym,{}).merge(v.symbolize_keys)


### PR DESCRIPTION
Ruby 3.1 comes with Psych 4, which has a major breaking change 
The new YAML loading methods (Psych 4) do not load aliases unless they get the `aliases: true` argument. 
The old YAML loading methods (Psych 3) do not support the aliases keyword.

### Related PR:
- https://github.com/paladinsoftware/cas/pull/232