### PR TITLE
Support for auth flow with separate FE app

### DIFF
--- a/app/controllers/casino/sessions_controller.rb
+++ b/app/controllers/casino/sessions_controller.rb
@@ -17,7 +17,10 @@ class CASino::SessionsController < CASino::ApplicationController
   def new
     tgt = current_ticket_granting_ticket
     return handle_signed_in(tgt) unless params[:renew].present? || tgt.nil?
-    redirect_to(params[:service]) if params[:gateway].present? && params[:service].present?
+    return redirect_to(params[:service]) if params[:gateway].present? && params[:service].present?
+    return head :unauthorized if request.xhr?
+
+    render 'sessions/new' # render login page if none of the above
   end
 
   def create


### PR DESCRIPTION
Return 401 from /login endpoint for AJAX requests instead of rendering login page.
This provides a clean and straightforward way for FE app to detect that user is not unauthorized and handle it appropriately.

### Full "separate FE app auth flow" description:

#### TL;DR
It's normal CAS flow with 2 changes:
- CAS server modified to return 401 instead of rendering login page if AJAX request was made
- FE would react to the 401 by opening CAS login page with "service" (go-back) url set to FE url

#### Full flow:
1. user opens `[payments_fe_url]` in a browser
2. FE loads and makes a request: GET `[payments_be_url]/sessions/new`
3. no rack session with CAS data -> BE redirects to `[cas_url]/login?service=[payments_be_url]/sessions/new`
4. no CAS session & AJAX request -> CAS responds with 401
5. FE detects 401 status (optionally also that request has been redirected and `[cas_url]/login` is the final URL) -> FE loads CAS login page but with its own URL as "service" param (`[cas_url]/login?service=[payments_fe_url]`)
6. no CAS session & non-AJAX request -> CAS renders login page
7. user logs in -> CAS creates its session
8. CAS redirects back to `[payments_fe_url]` which was passed as "service" param
9. FE loads and makes a request: GET `[payments_be_url]/sessions/new` (same as 2)
10. no rack session with CAS data -> BE redirects to `[cas_url]/login?service=[payments_be_url]/sessions/new` (same as 3)
11. CAS session already exists -> CAS redirects to "service" url it's been given, appending the "ticket" param - in this case `[payments_be_url]/sessions/new?ticket=blahblahblah`
12. BE verifies the ticket, creates rack session with CAS data and redirects to `[payments_be_url]/sessions/new`
13. BE detects rack session with CAS data -> responds with 204 "No content" and Set-Cookie header for session id cookie
14. FE detects session id cookie -> can proceed to load resources